### PR TITLE
feat: add Go bindings for OnlinePunctuation (CNN-BiLSTM)

### DIFF
--- a/online_punctuation.go
+++ b/online_punctuation.go
@@ -1,0 +1,65 @@
+package sherpa_onnx
+
+// #include <stdlib.h>
+// #include "c-api.h"
+import "C"
+import "unsafe"
+
+// OnlinePunctuationModelConfig configures the CNN-BiLSTM punctuation model.
+type OnlinePunctuationModelConfig struct {
+	CnnBilstm  string
+	BpeVocab   string
+	NumThreads C.int
+	Debug      C.int
+	Provider   string
+}
+
+// OnlinePunctuationConfig wraps the model config.
+type OnlinePunctuationConfig struct {
+	Model OnlinePunctuationModelConfig
+}
+
+// OnlinePunctuation holds a pointer to the C implementation.
+type OnlinePunctuation struct {
+	impl *C.struct_SherpaOnnxOnlinePunctuation
+}
+
+// NewOnlinePunctuation creates an online punctuation processor.
+func NewOnlinePunctuation(config *OnlinePunctuationConfig) *OnlinePunctuation {
+	cfg := C.struct_SherpaOnnxOnlinePunctuationConfig{}
+	cfg.model.cnn_bilstm = C.CString(config.Model.CnnBilstm)
+	defer C.free(unsafe.Pointer(cfg.model.cnn_bilstm))
+
+	cfg.model.bpe_vocab = C.CString(config.Model.BpeVocab)
+	defer C.free(unsafe.Pointer(cfg.model.bpe_vocab))
+
+	cfg.model.num_threads = config.Model.NumThreads
+	cfg.model.debug = config.Model.Debug
+	cfg.model.provider = C.CString(config.Model.Provider)
+	defer C.free(unsafe.Pointer(cfg.model.provider))
+
+	impl := C.SherpaOnnxCreateOnlinePunctuation(&cfg)
+	if impl == nil {
+		return nil
+	}
+	punc := &OnlinePunctuation{}
+	punc.impl = impl
+	return punc
+}
+
+// DeleteOnlinePunctuation frees the C resources.
+func DeleteOnlinePunctuation(punc *OnlinePunctuation) {
+	C.SherpaOnnxDestroyOnlinePunctuation(punc.impl)
+	punc.impl = nil
+}
+
+// AddPunct adds punctuation and truecasing to the input text.
+func (punc *OnlinePunctuation) AddPunct(text string) string {
+	cText := C.CString(text)
+	defer C.free(unsafe.Pointer(cText))
+
+	p := C.SherpaOnnxOnlinePunctuationAddPunct(punc.impl, cText)
+	defer C.SherpaOnnxOnlinePunctuationFreeText(p)
+
+	return C.GoString(p)
+}


### PR DESCRIPTION
## Summary

Add Go CGo bindings for the **OnlinePunctuation** C API (`c-api.h:1669-1702`), enabling the CNN-BiLSTM punctuation model in Go applications.

The C API for OnlinePunctuation has been available since sherpa-onnx v1.10.0+ but Go bindings were never added. This follows the exact same pattern as the existing `OfflinePunctuation` bindings (`sherpa_onnx.go:2102-2148`).

**New file:** `online_punctuation.go` (~65 lines)

### Types
- `OnlinePunctuationModelConfig` — `CnnBilstm`, `BpeVocab`, `NumThreads`, `Debug`, `Provider`
- `OnlinePunctuationConfig` — wraps model config
- `OnlinePunctuation` — holds C impl pointer

### Functions
- `NewOnlinePunctuation(config) *OnlinePunctuation`
- `DeleteOnlinePunctuation(punc)`
- `(*OnlinePunctuation).AddPunct(text string) string`

### Model
Uses the [sherpa-onnx-online-punct-en-2024-08-06](https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-online-punct-en-2024-08-06.tar.bz2) model (CNN-BiLSTM, 7 MB INT8, English + truecasing) — 10x smaller than ct-transformer (73 MB).

### Tested
Built and deployed in production ([moonshine-whisper](https://github.com/anatolykoptev/moonshine-whisper)) using build-time patches. Works correctly with `model.int8.onnx` + `bpe.vocab`.

Companion PR for type aliases: will be submitted to `k2-fsa/sherpa-onnx-go`

Refs k2-fsa/sherpa-onnx#1227