### PR TITLE
Expose per-stream hotwords API: NewOfflineStreamWithHotwords

### DIFF
--- a/sherpa_onnx.go
+++ b/sherpa_onnx.go
@@ -880,6 +880,26 @@ func NewOfflineStream(recognizer *OfflineRecognizer) *OfflineStream {
 	return stream
 }
 
+// NewOfflineStreamWithHotwords creates a stream with per-stream hotwords for
+// contextual biasing. Hotwords are tokens separated by space, phrases by '/'.
+// For BPE-based transducer models the tokens are BPE pieces preceded by '▁',
+// e.g. "▁I ▁LOVE ▁YOU/▁HELLO ▁WORLD".
+//
+// Only transducer recognizers support contextual biasing. Calling this on a
+// CTC, Paraformer, SenseVoice or Whisper recognizer will abort the process
+// (this is enforced inside sherpa-onnx upstream).
+//
+// The user is responsible to invoke [DeleteOfflineStream]() to free the
+// returned stream to avoid memory leak.
+func NewOfflineStreamWithHotwords(recognizer *OfflineRecognizer, hotwords string) *OfflineStream {
+	chw := C.CString(hotwords)
+	defer C.free(unsafe.Pointer(chw))
+
+	stream := &OfflineStream{}
+	stream.impl = C.SherpaOnnxCreateOfflineStreamWithHotwords(recognizer.impl, chw)
+	return stream
+}
+
 // Input audio samples for the offline stream.
 // Please only call it once. That is, input all samples at once.
 //


### PR DESCRIPTION
## Summary

The C API [`SherpaOnnxCreateOfflineStreamWithHotwords`](https://github.com/k2-fsa/sherpa-onnx/blob/master/sherpa-onnx/c-api/c-api.h) lets the caller create an offline ASR stream with per-stream hotwords for contextual biasing. The symbol is already linked into the Go binding, but only `SherpaOnnxCreateOfflineStream` had a Go wrapper, so Go callers had no way to pass per-request hotwords short of recreating the whole `OfflineRecognizer` (or living with the global `hotwords_file` baked in at construction).

This PR adds a thin wrapper:

```go
func NewOfflineStreamWithHotwords(recognizer *OfflineRecognizer, hotwords string) *OfflineStream
```

Format follows the upstream convention — tokens separated by space, phrases by `/`. For BPE transducer models the tokens are BPE pieces preceded by `▁`:

```go
stream := sherpa_onnx.NewOfflineStreamWithHotwords(rec, "▁HELLO ▁WORLD/▁I ▁LOVE ▁YOU")
defer sherpa_onnx.DeleteOfflineStream(stream)
```

## Why

- **Per-request / per-session hotwords**: ASR services can scope hotwords per HTTP call, per device, per skill, without rebuilding the recognizer.
- **No global state churn**: The recognizer (and its model session pool) stays alive; only the lightweight stream object is created with a different bias.
- **Symmetric with C API**: `SherpaOnnxCreateOfflineStream` and `SherpaOnnxCreateOfflineStreamWithHotwords` should both be reachable from Go.

## Caveat (in the doc comment)

Contextual biasing only works for transducer recognizers. sherpa-onnx upstream calls `SHERPA_ONNX_EXIT(-1)` if `CreateStream(hotwords)` is invoked on CTC, Paraformer, SenseVoice or Whisper. The doc comment on the new function makes this explicit so callers know they need to gate by model type.

## Test plan

- [x] `go build ./...` clean
- [ ] Manual: call `NewOfflineStreamWithHotwords` on a transducer recognizer (e.g. zipformer-multi-zh-hans) and confirm hotwords influence decoding
- [ ] Manual: confirm process aborts cleanly when called on a CTC recognizer (matching upstream behavior)

If maintainers want me to mirror the same wrapper into `sherpa-onnx-go-macos` and `sherpa-onnx-go-windows` I can open those PRs too.